### PR TITLE
Make codebase facts workable: source references as entities, rule persistence, skill grammar

### DIFF
--- a/skills/lemmalog/SKILL.md
+++ b/skills/lemmalog/SKILL.md
@@ -35,10 +35,14 @@ your context.
 
 1. **Assert as you verify.** The moment you confirm something — a call
    edge, a config value, a decision, a step completed — assert it:
-   `S --rel[conf]--> O`. Omit the confidence tag for read-and-verified;
-   tag inferences `[0.4]`–`[0.7]`. Anchor evidence with
-   `located(Entity, "file:line")` (or any stable reference) so provenance
-   survives derivation. Never assert what you haven't checked.
+   `S --rel[conf]--> O`. Tag read-and-verified facts `[1.0]` and inferences
+   `[0.4]`–`[0.7]`. Do not omit the tag on anything you expect to derive over:
+   the default is 0.9 and confidence is a product down the proof chain, so four
+   hops of "verified" facts land at 0.66 and a deep closure decays to noise.
+   Anchor evidence with `located(Entity, "file:line")` (or any stable
+   reference) so provenance survives derivation — source references are valid
+   entity tokens as long as they contain no spaces. Never assert what you
+   haven't checked.
 2. **Install rules when a pattern repeats.** If you ask the same shape of
    question twice, write the Datalog for it: transitive closures, guard
    tracking, status rollups, `count`/`min`/`max`/`sum` aggregates. Rules
@@ -91,6 +95,11 @@ decision(Id, What)            % choices made, so state stays complete
 - Bare capitalized words are **variables** — quote entity names:
   `reports_to("Alice", Y)`, never `reports_to(Alice, Y)`.
 - Fact line protocol: `S --rel[conf]--> O`, one per line.
+- **An asserted fact is `current(S, rel, O)`, not `rel(S, O)`.** Rule bodies
+  match the triple: `reaches(X, Y) :- current(X, depends_on, Y).` Writing
+  `depends_on(X, Y)` instead installs cleanly, reports a backfill count, and
+  then derives nothing — the failure is silent, so check a new rule with one
+  `lemmalog_query` before building on it.
 - Rule syntax: `head(X, Y) :- atom(X, Y), X \= Z.` with `!atom` negation,
   `now(T)`, comparisons, arithmetic; aggregates only in heads.
 - Errors are actionable: every `isError` result carries the offending

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -107,9 +107,15 @@ fn entity_token_problem(s: &str) -> Option<String> {
         Some("looks like prose (more than 8 words) — entity names are short".to_string())
     } else if !s
         .chars()
-        .all(|c| c.is_alphanumeric() || matches!(c, '_' | '-' | '\'' | ' '))
+        .all(|c| c.is_alphanumeric() || matches!(c, '_' | '-' | '\'' | ' ' | '/' | '.' | ':' | '#'))
     {
-        Some("contains punctuation or prose characters — entity names use letters, digits, '_', '-', apostrophes".to_string())
+        Some("contains punctuation or prose characters — entity names use letters, digits, '_', '-', apostrophes, and '/', '.', ':', '#' in source references".to_string())
+    } else if s.contains(' ') && s.chars().any(|c| matches!(c, '/' | '.' | ':' | '#')) {
+        // Path characters are allowed so that source references
+        // (`src/agent.rs:118`) can be entities, but only as single tokens:
+        // punctuation *plus* spaces is the signature of leaked prose, which
+        // is exactly what strict validation exists to drop.
+        Some("looks like prose — source references must not contain spaces (`src/agent.rs:118`, not `see src/agent.rs, line 118`)".to_string())
     } else {
         None
     }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -770,6 +770,8 @@ fn unesc(s: &str) -> String {
 }
 
 const SNAPSHOT_MAGIC: &str = "LEMMALOG1";
+/// The batch `new()` installs from `DEFAULT_RULES`; never persisted.
+const BOOTSTRAP_BATCH: &str = "b0";
 /// Pre-rename snapshots (read-only compatibility).
 const SNAPSHOT_MAGIC_V0: &str = "CORTEXLOG1";
 
@@ -784,6 +786,18 @@ impl<X: Extractor> AgentMemory<X> {
         let _ = writeln!(out, "{SNAPSHOT_MAGIC}");
         let _ = writeln!(out, "NOW\t{}", self.engine.now);
         let _ = writeln!(out, "RULES\t{}", esc(&self.extra_rules));
+        // Batches installed after construction (`install_rules`) are not in
+        // `extra_rules`, so persisting only that field drops every rule an
+        // agent installed — silently, since base facts still load and the
+        // derived views simply come back empty. Batch ids are positional
+        // (`b{len}`), so replaying non-bootstrap batches in order restores
+        // them under the same ids and `uninstall` keeps working.
+        for (id, src) in self.engine.batches() {
+            if id == BOOTSTRAP_BATCH {
+                continue; // reinstalled by `new()` from DEFAULT_RULES
+            }
+            let _ = writeln!(out, "RULEB\t{}\t{}", esc(&id), esc(&src));
+        }
         for ep in &self.episodes {
             let _ = writeln!(
                 out,
@@ -838,6 +852,7 @@ impl<X: Extractor> AgentMemory<X> {
             return Err("not a lemmalog snapshot".into());
         }
         let mut rules = String::new();
+        let mut batch_srcs: Vec<String> = Vec::new();
         let mut now = 0i64;
         let mut episodes = Vec::new();
         let mut escalations = Vec::new();
@@ -849,6 +864,13 @@ impl<X: Extractor> AgentMemory<X> {
             match tag {
                 "NOW" => now = rest.parse()?,
                 "RULES" => rules = unesc(rest),
+                "RULEB" => {
+                    let mut f = rest.splitn(2, '\t');
+                    let (Some(_id), Some(src)) = (f.next(), f.next()) else {
+                        return Err("bad RULEB record".into());
+                    };
+                    batch_srcs.push(unesc(src));
+                }
                 "EP" => {
                     let mut f = rest.splitn(4, '\t');
                     let (Some(id), Some(ts), Some(speaker), Some(txt)) =
@@ -895,7 +917,19 @@ impl<X: Extractor> AgentMemory<X> {
                 _ => {}
             }
         }
-        let mut m = AgentMemory::new(extractor, &rules)?;
+        let mut m = if batch_srcs.is_empty() {
+            // Legacy snapshot (or nothing installed past the bootstrap).
+            AgentMemory::new(extractor, &rules)?
+        } else {
+            // `extra_rules` became a batch at construction, so it is already
+            // in `batch_srcs`; passing it again would install it twice.
+            let mut m = AgentMemory::new(extractor, "")?;
+            for src in &batch_srcs {
+                m.engine.install_program(src)?;
+            }
+            m.extra_rules = rules;
+            m
+        };
         m.escalations = escalations;
         m.episodes = episodes;
         m.episode_counter = m.episodes.len() as u64;

--- a/tests/agent_test.rs
+++ b/tests/agent_test.rs
@@ -293,3 +293,34 @@ fn observe_extracted_applies_policy_and_reports_drops() {
         vec!["O=acme".to_string()]
     );
 }
+
+#[test]
+fn source_references_are_valid_entities() {
+    use lemmalog::agent::parse_protocol_reported;
+    let (facts, dropped) = parse_protocol_reported(
+        "sketch_mode --located--> src/features/sketchMode/bind.ts\n\
+         entity_token_problem --defined_at--> src/agent.rs:92\n\
+         parser --tracked_by--> JordyZomer/lemmalog#12\n\
+         sketch_mode --depends_on--> engine_scene",
+        1.0,
+    );
+    assert_eq!(facts.len(), 4, "dropped: {dropped:?}");
+    assert!(dropped.is_empty(), "{dropped:?}");
+    assert_eq!(facts[1].obj, "src/agent.rs:92");
+}
+
+#[test]
+fn punctuation_with_spaces_is_still_prose() {
+    use lemmalog::agent::parse_protocol_reported;
+    let (facts, dropped) = parse_protocol_reported(
+        "thing --located--> see src/agent.rs, around line 118\n\
+         thing --noted--> Yes. Confirmed.",
+        1.0,
+    );
+    assert!(facts.is_empty(), "{facts:?}");
+    assert_eq!(dropped.len(), 2);
+    assert!(
+        dropped.iter().all(|(_, r)| r.contains("prose")),
+        "{dropped:?}"
+    );
+}

--- a/tests/agent_test.rs
+++ b/tests/agent_test.rs
@@ -324,3 +324,38 @@ fn punctuation_with_spaces_is_still_prose() {
         "{dropped:?}"
     );
 }
+
+#[test]
+fn snapshot_preserves_rules_installed_after_construction() {
+    let dir = std::env::temp_dir().join("lemmalog-test-batches");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("mem.snapshot");
+    let path = path.to_str().unwrap();
+
+    // Nothing in the constructor: this is how the MCP server runs.
+    let mut m = mem("");
+    m.observe_at("alice --manager--> bob\nbob --manager--> carol", 100);
+    let b = m
+        .install_rules(
+            "reports_to(X, Y) :- current(X, \"manager\", Y).\n\
+             reports_to(X, Z) :- reports_to(X, Y), reports_to(Y, Z).",
+        )
+        .unwrap();
+    m.maintain(100);
+    assert_eq!(m.ask("reports_to(\"alice\", Y)").unwrap().len(), 2);
+
+    m.save(path).unwrap();
+    let mut m2 = AgentMemory::load(MockExtractor::new(0.9), path).unwrap();
+
+    assert_eq!(
+        m2.ask("reports_to(\"alice\", Y)").unwrap(),
+        vec!["Y=bob".to_string(), "Y=carol".to_string()],
+        "an installed rule batch must survive a reload"
+    );
+    // batch identity survives, so uninstall still targets the same batch
+    let ids: Vec<String> = m2.rule_batches().into_iter().map(|(i, _)| i).collect();
+    assert!(ids.contains(&b), "batch {b} missing from {ids:?}");
+    assert!(m2.uninstall_rules(&b));
+    m2.maintain(200);
+    assert!(m2.ask("reports_to(\"alice\", Y)").unwrap().is_empty());
+}


### PR DESCRIPTION
I tried using lemmalog for a use case slightly off the benchmarked one — tracking facts about a codebase and deriving findings from them, rather than conversational memory — and hit three things. Two are bugs, one is documentation. Each one cost real time to diagnose, and all three share a failure shape: the engine reports success and then produces nothing.

Happy to split this into separate PRs if you'd rather take them independently.

## 1. Source references cannot be entities

Entity tokens allowed only letters, digits, `_`, `-`, apostrophes and spaces, so every path-anchored fact was dropped:

```
sketch_mode --located--> src/features/sketchMode/bind.ts
  → "contains punctuation or prose characters"
```

That makes the skill's own evidence convention — `located(Entity, "file:line")` — impossible to express through the line protocol, since it has no quoting escape hatch. For facts about code the anchor *is* the provenance, so this rules out the whole category.

`/`, `.`, `:` and `#` are now accepted, but **only in tokens without spaces**. Punctuation *plus* spaces is the signature of leaked deliberation (`see src/agent.rs, around line 118`), which is what strict validation exists to drop, so the prose guard keeps its teeth. Tests cover both directions.

## 2. Rules installed through MCP are lost on reload

`save` writes only `extra_rules`, the program passed to `AgentMemory::new`. Batches added later by `install_rules` live in `engine.rule_batches` and were never persisted.

This lands squarely on the documented MCP path: `lemmalog-mcp` constructs with `""`, so *every* rule an agent installs is in the lost set, and "derived relations rebuild on load" holds only for snapshots whose rules came in through the constructor.

It's silent, which is what makes it expensive. Base facts reload fine, so a restarted session answers `(no answers)` to a query that worked a moment earlier and reports a fact it derived yesterday as `[unknown fact]` — indistinguishable from never having asserted anything.

Non-bootstrap batches are now written as `RULEB` records and replayed in order on load. Batch ids are positional (`b{len}`), so replaying restores them unchanged and `uninstall` still targets the batch the agent installed. `extra_rules` is itself among those batches, so the replay path constructs with `""` rather than installing it twice. Unknown tags were already skipped on load, so old snapshots still read and new ones stay readable by an older binary.

## 3. SKILL.md doesn't say what shape an asserted fact has

Two things an agent reading SKILL.md can't learn, both of which I rediscovered the slow way:

**An asserted fact is `current(S, rel, O)`, not `rel(S, O)`.** The grammar section only shows `head(X, Y) :- atom(X, Y)`, so the natural first rule is:

```
reaches(X, Y) :- depends_on(X, Y).
```

which installs cleanly, reports `installed b1; backfill derived +7 facts`, and derives nothing. A wrong rule and a correct one are indistinguishable from their install output — hence the added advice to verify a new rule with one query before building on it. (The README has this right; the skill is what the agent actually reads.)

**Confidence is a product down the proof chain, and the default is 0.9.** "Omit the confidence tag for read-and-verified" therefore decays a four-hop closure over verified facts to 0.66, and step 8's "a conclusion's confidence is its minimum edge confidence" then argues against believing anything derived. For facts read out of a file, `[1.0]` is the honest tag.

## Verification

`cargo test --features mcp` is green, including three added tests: source references accepted, prose-with-punctuation still rejected, and a rule batch surviving save/load with its id intact (this one fails on `main`).

End to end after the fixes, 62 facts about a codebase's architectural invariants derive findings like "invariant with no test, marked fragile, and where to look" — and they survive a restart, which was the point.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
