### PR TITLE
Separate valid-time from read-time: a backdated observe silently hides later facts

### DIFF
--- a/skills/lemmalog/SKILL.md
+++ b/skills/lemmalog/SKILL.md
@@ -161,6 +161,13 @@ aggregates need):
   `lemmalog_query` before building on it.
 - Rule syntax: `head(X, Y) :- atom(X, Y), X \= Z.` with `!atom` negation,
   `now(T)`, comparisons, arithmetic; aggregates only in heads.
+- Time is bitemporal, and the two clocks are separate. `ts` on
+  `lemmalog_observe` is the **valid-from** time of the facts in that call;
+  `now(T)` in a rule is the reader's present, synced to the wall clock on
+  every read. So backdating a batch is safe — it dates those facts without
+  hiding anything asserted after them. Omit `ts` unless the facts really
+  are about the past, and give one call one coherent timestamp rather than
+  mixing eras in a single batch.
 - Errors are actionable: every `isError` result carries the offending
   input, the reason, and a hint — fix and resend; `lemmalog_observe`
   reports dropped lines with reasons, so a zero-add result is loud, not

--- a/src/bin/lemmalog-mcp.rs
+++ b/src/bin/lemmalog-mcp.rs
@@ -12,6 +12,13 @@
 //! and asserts triples via `observe`; Lemmalog derives closures,
 //! temporal views, canonicalizations, aggregations and answers `query`
 //! and `why` deterministically.
+//!
+//! Time is bitemporal and the two clocks are kept apart: an `observe`
+//! carries the *valid-from* time of the facts it asserts, while every read
+//! path syncs the engine clock to the wall clock before deriving (see
+//! `sync_clock`). Reads therefore answer as of the present no matter what
+//! order episodes were ingested in, and backdating a batch cannot hide
+//! facts asserted after it.
 
 #![cfg(feature = "mcp")]
 
@@ -85,7 +92,7 @@ fn main() {
 fn tools() -> J {
     json!([
         tool("lemmalog_observe",
-            "Assert facts into memory (host model does extraction). Input: facts in the line protocol 'S --rel[conf]--> O', one per line; optional ts integer (default: engine clock). Example: 'Alice --works_at--> Acme\\nBob --manager--> Carol'.", &["facts", "ts"], &["facts"]),
+            "Assert facts into memory (host model does extraction). Input: facts in the line protocol 'S --rel[conf]--> O', one per line; optional ts integer = the facts' valid-from time (default: now). Backdating with ts is safe: it sets valid-time only, never the clock reads use. Example: 'Alice --works_at--> Acme\\nBob --manager--> Carol'.", &["facts", "ts"], &["facts"]),
         tool("lemmalog_retract",
             "Retract facts that turned out to be WRONG (line protocol, same as observe). Open matching rows are removed and invalidation propagates: the response reports which derived facts died as a consequence. For a value that merely CHANGED, prefer re-asserting the same relation (the update policy supersedes).", &["facts"], &["facts"]),
         tool("lemmalog_query",
@@ -109,7 +116,7 @@ fn tools() -> J {
         tool("lemmalog_changes",
             "Resync after a context reset or another agent's work: everything asserted, derived, or retracted since an epoch. Input: optional `since` epoch integer (default: 0 = everything, capped). The response carries the current epoch — checkpoint it and pass it back next time.", &["since"], &[]),
         tool("lemmalog_save", "Persist memory to LEMMALOG_MCP_PATH.", &[], &[]),
-        tool("lemmalog_run", "Run one maintenance epoch (usually automatic).", &[], &[]),
+        tool("lemmalog_run", "Sync the clock to the present and run one maintenance epoch (usually automatic — every read does it).", &[], &[]),
     ])
 }
 
@@ -193,6 +200,33 @@ fn engine_of(state: &mut State) -> &mut Engine {
     &mut state.memory.engine
 }
 
+/// Wall-clock seconds since the Unix epoch.
+fn wall_clock() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// Advance the engine clock to the present and re-derive temporal views.
+///
+/// `now` is the *reader's* present, not a side effect of the last write.
+/// Without this, `engine.now` is whatever timestamp the last `observe`
+/// passed, so a backdated ingest silently hides every fact asserted at a
+/// later `ts` from `current/3` — the fact stays in `edge`, but fails the
+/// `VF =< T` guard. Reads sync forward; ingest keeps honouring its own
+/// `ts` as valid-time. The clock only ever moves forward here: a
+/// future-dated fact must not drag the present backwards.
+fn sync_clock(state: &mut State) {
+    let t = wall_clock();
+    let e = &mut state.memory.engine;
+    if t > e.now {
+        e.set_now(t);
+        e.invalidate_derived();
+        let _ = e.run();
+    }
+}
+
 fn truncate(s: &str, n: usize) -> String {
     if s.chars().count() <= n {
         s.to_string()
@@ -259,16 +293,18 @@ fn tool_call(
     let inner: Result<String, String> = match name {
         "lemmalog_observe" => {
             let facts = args["facts"].as_str().unwrap_or_default();
-            let ts = args["ts"].as_i64();
+            // No ts means "now" — the wall clock, never the engine clock,
+            // which is only ever a record of the last write.
+            let ts = args["ts"].as_i64().unwrap_or_else(wall_clock);
             let mem = &mut state.memory;
-            let (report, dropped) = match ts {
-                Some(t) => mem.observe_extracted(facts, t),
-                None => {
-                    let now = mem.engine.now;
-                    mem.observe_extracted(facts, now)
-                }
-            };
-            let now = mem.engine.now;
+            let (report, dropped) = mem.observe_extracted(facts, ts);
+            // Facts keep `ts` as their valid-time (VF), but the derived view
+            // is as of the present: backdating an episode must not rewind
+            // `current/3` past everything already asserted.
+            let now = wall_clock().max(mem.engine.now);
+            if now > mem.engine.now {
+                mem.engine.invalidate_derived();
+            }
             mem.maintain(now);
             let mut out = format!(
                 "added={} updated={} noop={} escalations={}",
@@ -306,6 +342,9 @@ fn tool_call(
             if facts.trim().is_empty() {
                 Err("input: `facts` is required — line-protocol facts to retract".to_string())
             } else {
+                // invalidation is computed against the derived view, so the
+                // clock has to be current before we decide what dies
+                sync_clock(state);
                 let (done, missing, died) = state.memory.retract_facts(facts);
                 let mut out = String::new();
                 if !done.is_empty() {
@@ -345,6 +384,7 @@ fn tool_call(
         }
         "lemmalog_changes" => {
             let since = args["since"].as_i64().unwrap_or(0).max(0) as u64;
+            sync_clock(state);
             let e = engine_of(state);
             let events = e.changes_since(since);
             let epoch = e.epoch();
@@ -378,6 +418,7 @@ fn tool_call(
         }
         "lemmalog_query" => {
             let goal = args["goal"].as_str().unwrap_or_default().to_string();
+            sync_clock(state);
             match engine_of(state).ask(&goal) {
                 Ok(rows) => Ok(if rows.is_empty() {
                     empty_query_hint(engine_of(state), &goal)
@@ -392,6 +433,7 @@ fn tool_call(
         }
         "lemmalog_query_deep" => {
             let goal = args["goal"].as_str().unwrap_or_default().to_string();
+            sync_clock(state);
             match engine_of(state).ask_deep(&goal) {
                 Ok(rows) => Ok(if rows.is_empty() {
                     empty_query_hint(engine_of(state), &goal)
@@ -406,6 +448,7 @@ fn tool_call(
         }
         "lemmalog_why" => {
             let fact = args["fact"].as_str().unwrap_or_default().to_string();
+            sync_clock(state);
             match parse_fact_atom(&fact) {
                 Ok((pred, parts)) => {
                     let vals: Vec<Value> = parts
@@ -424,6 +467,7 @@ fn tool_call(
         }
         "lemmalog_install_rules" => {
             let rules = args["rules"].as_str().unwrap_or_default();
+            sync_clock(state);
             match engine_of(state).install_program(rules) {
                 Ok(id) => {
                     let n = engine_of(state).run();
@@ -436,6 +480,7 @@ fn tool_call(
         }
         "lemmalog_uninstall" => {
             let id = args["id"].as_str().unwrap_or_default().to_string();
+            sync_clock(state);
             if engine_of(state).uninstall(&id) {
                 let _ = engine_of(state).run();
                 Ok(format!("uninstalled {id}; derivations recomputed"))
@@ -468,6 +513,7 @@ fn tool_call(
                     "isError": true
                 }));
             }
+            sync_clock(state);
             let e = engine_of(state);
             let now = e.now;
             let mut extra: Vec<(String, Vec<Value>)> = Vec::new();
@@ -511,6 +557,7 @@ fn tool_call(
                     "isError": true
                 }));
             }
+            sync_clock(state);
             let e = engine_of(state);
             for c in &aliases {
                 canonical::assert_alias(e, &c.subj, &c.obj, c.confidence);
@@ -540,11 +587,13 @@ fn tool_call(
             if query.trim().is_empty() {
                 Err("input: `query` is required — the natural-language question the context should serve".to_string())
             } else {
+                sync_clock(state);
                 Ok(state.memory.context_for_query_rich(&query, budget))
             }
         }
         "lemmalog_dump" => {
             let pred = args["pred"].as_str().unwrap_or_default();
+            sync_clock(state);
             let e = engine_of(state);
             let mut preds: Vec<&String> = e.relations.keys().collect();
             preds.sort();
@@ -572,8 +621,9 @@ fn tool_call(
             }
         }
         "lemmalog_run" => {
+            sync_clock(state);
             let n = engine_of(state).run();
-            Ok(format!("+{n} facts"))
+            Ok(format!("+{n} facts (clock {})", engine_of(state).now))
         }
         other => {
             // models invent tool names; teach instead of rejecting —

--- a/src/bin/lemmalog-mcp.rs
+++ b/src/bin/lemmalog-mcp.rs
@@ -667,7 +667,8 @@ fn tool_call(
     if !is_error
         && matches!(
             name,
-            "lemmalog_observe" | "lemmalog_install_rules" | "lemmalog_uninstall" | "lemmalog_canonicalize"
+            "lemmalog_observe" | "lemmalog_retract" | "lemmalog_install_rules"
+                | "lemmalog_uninstall" | "lemmalog_canonicalize"
         )
     {
         if let Some(p) = path {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -510,6 +510,24 @@ impl Engine {
         self.now = now;
     }
 
+    /// Force a full re-derivation on the next `run()`.
+    ///
+    /// Seminaive evaluation fires a rule only for facts in the epoch delta,
+    /// so moving `now` alone never re-fires `now(T)` rules over facts that
+    /// are already resident: a temporal view like
+    /// `current(E,R,O) :- edge(E,R,O,VF,VT,_), now(T), VF =< T, T < VT.`
+    /// keeps answering as of the clock that was set when each edge arrived.
+    /// Callers that advance the clock and need the view to follow must
+    /// invalidate first. Cost is a full recompute, so this belongs on paths
+    /// that run once per agent turn — reads, clock syncs, and the MCP
+    /// `observe` handler. Never call it inside a bulk replay loop
+    /// (`lemmalog-bench` ingest): one recompute per episode is quadratic in
+    /// corpus size, and a replay that feeds timestamps in order does not
+    /// need it.
+    pub fn invalidate_derived(&mut self) {
+        self.program_dirty = true;
+    }
+
     // ----------------------------------------------------------- stratify
 
     /// Stratum assignment: depth(p) = max over rules defining p of

--- a/tests/agent_test.rs
+++ b/tests/agent_test.rs
@@ -294,6 +294,48 @@ fn observe_extracted_applies_policy_and_reports_drops() {
     );
 }
 
+/// Regression: moving the clock does not refresh temporal views on its own.
+///
+/// Seminaive evaluation fires a rule only for facts in the epoch delta, so a
+/// `now(T)` view like `current/3` keeps answering as of the clock that was
+/// set when each edge arrived. Production hit this from the other side: a
+/// backdated batch rewound the clock, and every fact whose VF was later
+/// silently stopped projecting — still in `edge`, absent from `current`, and
+/// no amount of re-running maintenance brought it back. `invalidate_derived`
+/// is the documented escape hatch, and the MCP read paths call it via
+/// `sync_clock`.
+#[test]
+fn seminaive_does_not_refresh_now_rules_without_invalidation() {
+    let mut m = mem("");
+    // valid from t=2000, but derived while the clock sits at 1000
+    m.observe_extracted("late --relates_to--> ticket", 2000);
+    m.maintain(1000);
+    assert!(
+        m.ask("current(\"late\", R, O)").unwrap().is_empty(),
+        "VF=2000 must not project at clock 1000"
+    );
+    // the edge is resident either way
+    assert_eq!(m.ask("edge(\"late\", R, O, VF, VT, TS)").unwrap().len(), 1);
+
+    // Pins current design, not a requirement: advancing the clock alone
+    // leaves the view stale because there is no delta to fire on. If
+    // `set_now` ever learns to invalidate when clock-dependent rules exist,
+    // delete this assertion — the two around it are the regression guard.
+    m.maintain(3000);
+    assert!(
+        m.ask("current(\"late\", R, O)").unwrap().is_empty(),
+        "clock advance alone does not refresh — this is why invalidate_derived exists"
+    );
+
+    // invalidation re-seeds the delta and the view catches up
+    m.engine.invalidate_derived();
+    m.maintain(3000);
+    assert_eq!(
+        m.ask("current(\"late\", R, O)").unwrap().len(),
+        1,
+        "after invalidation the fact projects at clock 3000"
+    );
+}
 #[test]
 fn source_references_are_valid_entities() {
     use lemmalog::agent::parse_protocol_reported;


### PR DESCRIPTION
`engine.now` is doing two incompatible jobs: it is the valid-from stamp for facts being written, and it is the "present" that `now(T)` reads. Because `observe` sets it and nothing else ever does, the read clock is wherever the last write happened to leave it. Replay history out of order and the clock goes backwards — every fact with a later VF stops projecting through `current/3` and does not come back.

Measured on a real store: **79 of 823 edges resident in `edge` and absent from `current`** — three weeks of accumulated investigation state, invisible to `lemmalog_query`, `lemmalog_context`, and `lemmalog_dump` alike.

### Why it's permanent rather than transient

Seminaive evaluation is what turns a temporary clock skew into permanent loss. `fire_delta_version` returns early when a predicate has no delta tuples, so moving the clock never re-fires a `now(T)` rule over facts already resident. `lemmalog_run` can't recover them either — `run()` doesn't touch `now`, and there's no delta to fire on. Then `save` persists the rewound `NOW` and `load` re-derives everything as of it, so a restart reproduces the loss faithfully.

Nothing in the tool responses indicates this. `observe` reported `added=N`, the facts were genuinely added, and every subsequent read simply didn't see them.

### How I hit it

A backfill session replayed a month of prior work with explicit `ts` per historical session, in two batches — the first ascending to Aug 31, the second covering Aug 3–10 afterwards. That left the clock three weeks in the past. The next session passed no `ts` at all, inherited the stale clock through `None => engine.now`, and its 722 edges landed at the rewound timestamp. Everything from the first batch after that instant vanished from the view.

Nobody did anything unreasonable. Backdating is a documented feature of the `ts` argument.

### The fix

Two parts, both in `31c758c`:

- `Engine::invalidate_derived()` forces a full re-derivation on the next `run()`, reusing the existing `program_dirty` path. Cost is a full recompute, so the doc comment is explicit that the bench ingest loop must not call it — one recompute per episode is quadratic in corpus size.
- The MCP server syncs the clock to wall-clock and invalidates before deriving, on every read path plus `retract` (whose invalidation is computed against the derived view, so the clock has to be current before deciding what dies) and `changes`. Ingest keeps `ts` as valid-time only, and `ts` defaults to the wall clock rather than the stale engine clock.

Backdating stays fully supported and is now safe by construction.

### The smaller change I didn't make

Clamping `set_now` to `ts.max(self.now)` is one line and stops the rewind. It also corrupts valid-time: `assert_open` takes VF from `engine.now`, so a clamp rewrites a backdated episode's VF to the running maximum, and `dated`/`happened_before` inherit the wrong dates.

The corpora need genuine out-of-order timestamps. LongMemEval's `haystack_dates` are not monotonic within a single item — `17:50, 14:47, 17:15` in the first one I looked at — which is why `longmemeval.rs:99` sorts by `ts` before replay. Separating valid-time from read-time is the larger diff but the only one that leaves replay semantics intact.

### `63ffe52` — unrelated bug found while wiring the above

`lemmalog_retract` mutates the store but isn't in the save-on-mutate list, so the snapshot is never rewritten. The retraction and every derived fact that died with it return on the next start. That's worse than never retracting, because the response already reported the consequences as applied.

### Verification

`tests/agent_test.rs` gets a regression test that pins all three behaviors: a fact with VF ahead of the clock doesn't project, advancing the clock alone doesn't refresh it (documenting the seminaive limitation the fix works around), and invalidating makes it project. 66 tests pass across the suite; `llm_test` skipped, since it wants a live endpoint.

End-to-end against the affected snapshot, `current` went 744 → 823 and matched `edge` exactly.

One judgment call worth your review: I put `sync_clock` on `dump` and `why` as well as the query paths. It makes them consistent with everything else, at the cost of a recompute on what were previously pure reads.
